### PR TITLE
remove notLocalHost

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "lint": "npm-run-all lint:*",
     "lint:css": "stylelint 'public/*.css'",
     "lint:js": "eslint .",
-    "start": "cross-env NODE_ENV=production node server/portal_server",
+    "start": "node server/portal_server",
     "test": "mocha",
     "version": "node scripts/version"
   }

--- a/server/config.js
+++ b/server/config.js
@@ -3,7 +3,7 @@ const convict = require('convict');
 const conf = convict({
   s3_bucket: {
     format: String,
-    default: 'localhost',
+    default: '',
     env: 'P2P_S3_BUCKET'
   },
   redis_host: {
@@ -19,18 +19,17 @@ const conf = convict({
   },
   analytics_id: {
     format: String,
-    default: 'UA-101393094-1',
+    default: '',
     env: 'GOOGLE_ANALYTICS_ID'
   },
   sentry_id: {
     format: String,
-    default:
-      'https://cdf9a4f43a584f759586af8ceb2194f2@sentry.prod.mozaws.net/238',
+    default: '',
     env: 'P2P_SENTRY_CLIENT'
   },
   sentry_dsn: {
     format: String,
-    default: 'localhost',
+    default: '',
     env: 'P2P_SENTRY_DSN'
   },
   env: {
@@ -45,8 +44,3 @@ conf.validate({ allowed: 'strict' });
 
 const props = conf.getProperties();
 module.exports = props;
-
-module.exports.notLocalHost =
-  props.env === 'production' &&
-  props.s3_bucket !== 'localhost' &&
-  props.sentry_dsn !== 'localhost';

--- a/server/log.js
+++ b/server/log.js
@@ -1,12 +1,12 @@
 const conf = require('./config.js');
 
-const notLocalHost = conf.notLocalHost;
+const isProduction = conf.env === 'production'
 
 const mozlog = require('mozlog')({
   app: 'FirefoxFileshare',
-  level: notLocalHost ? 'INFO' : 'verbose',
-  fmt: notLocalHost ? 'heka' : 'pretty',
-  debug: !notLocalHost
+  level: isProduction ? 'INFO' : 'verbose',
+  fmt: isProduction ? 'heka' : 'pretty',
+  debug: !isProduction
 });
 
 module.exports = mozlog;

--- a/server/storage.js
+++ b/server/storage.js
@@ -6,8 +6,6 @@ const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
 
-const notLocalHost = conf.notLocalHost;
-
 const mozlog = require('./log.js');
 
 const log = mozlog('portal.storage');
@@ -22,7 +20,7 @@ redis_client.on('error', err => {
   log.info('Redis:', err);
 });
 
-if (notLocalHost) {
+if (conf.s3_bucket) {
   module.exports = {
     filename: filename,
     exists: exists,

--- a/test/aws.storage.test.js
+++ b/test/aws.storage.test.js
@@ -3,9 +3,6 @@ const sinon = require('sinon');
 const proxyquire = require('proxyquire');
 const crypto = require('crypto');
 
-const conf = require('../server/config.js');
-conf.notLocalHost = true;
-
 const redisStub = {};
 const exists = sinon.stub();
 const hget = sinon.stub();
@@ -52,7 +49,10 @@ const storage = proxyquire('../server/storage', {
   './log.js': function() {
     return logStub;
   },
-  'aws-sdk': awsStub
+  'aws-sdk': awsStub,
+  './config.js': {
+    s3_bucket: 'test'
+  }
 });
 
 describe('Testing Length using aws', function() {

--- a/test/local.storage.test.js
+++ b/test/local.storage.test.js
@@ -2,8 +2,7 @@ const assert = require('assert');
 const sinon = require('sinon');
 const proxyquire = require('proxyquire');
 
-const conf = require('../server/config.js');
-conf.notLocalHost = false;
+// const conf = require('../server/config.js');
 
 const redisStub = {};
 const exists = sinon.stub();

--- a/views/download.handlebars
+++ b/views/download.handlebars
@@ -2,11 +2,13 @@
 <html>
 <head>
   <title>Download your file</title>
-  {{> sentry dsn=dsn}}
+  {{#if dsn}}
+    {{> sentry dsn=dsn}}
+  {{/if}}
   <script src="/bundle.js"></script>
   <link rel="stylesheet" href="https://code.cdn.mozilla.net/fonts/fira.css" />
   <link rel="stylesheet" type="text/css" href="/main.css" />
-  {{#if shouldRenderAnalytics}}
+  {{#if trackerId}}
     {{> analytics trackerId=trackerId}}
   {{/if}}
 </head>

--- a/views/index.handlebars
+++ b/views/index.handlebars
@@ -2,11 +2,13 @@
 <html>
 <head>
   <title>Firefox Fileshare</title>
-  {{> sentry dsn=dsn}}
+  {{#if dsn}}
+    {{> sentry dsn=dsn}}
+  {{/if}}
   <script src="/bundle.js"></script>
   <link rel="stylesheet" href="https://code.cdn.mozilla.net/fonts/fira.css" />
   <link rel="stylesheet" type="text/css" href="/main.css" />
-  {{#if shouldRenderAnalytics}}
+  {{#if trackerId}}
     {{> analytics trackerId=trackerId}}
   {{/if}}
 </head>


### PR DESCRIPTION
the `notLocalHost` field is problematic because it causes unexpected behavior when a new parameter is added to it but the environment hasn't caught up with the new variable. As example, adding the sentry_dsn, instead of simply not using sentry it forces the storage module to use the local file system instead of s3 if that env isn't set. It's better to have each variable control only the aspect of the code it's responsible for.

cc @abhinadduri 